### PR TITLE
Improve mobile view

### DIFF
--- a/gapvis/joth.html
+++ b/gapvis/joth.html
@@ -5,6 +5,7 @@
     <title>GapVis: Visual Interface for Reading Ancient Texts</title>
     <meta name="description" content="GapVis is a visual interface for reading ancient texts for the Google Ancient Places project.">
     <meta name="author" content="Nick Rabinowitz / Google Ancient Places Project">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
 	
     <!--[if lt IE 9]>
     <script src="http://html5shim.googlecode.com/svn/trunk/html5.js">
@@ -88,7 +89,7 @@
             <a href="http://www.perseids.org/sites/joth">Journey of the Hero</a>
         </div>
     </div>
-    <div class="row">
+    <div>
         <div id="app-view" role="main" class="clearfix"></div>
     </div>
         <footer>


### PR DESCRIPTION
* Add viewport so Bootstrap works correctly on mobile (see [Bootstrap docs](https://getbootstrap.com/docs/3.3/css/))
* Remove double `<id class="row">`. This fixes a bunch of spacing issues   when the page is `sm` or `xs`. I think this is because of the way the   margins interfere with each other when there are two rows nested within each other that both have the styling `margin-left/right` of `-15px`.

### Before (mobile)

<img width="512" alt="before-mobile" src="https://user-images.githubusercontent.com/3039310/39382787-af973caa-4a34-11e8-9b40-1dbcbf9e3524.png">

### After (mobile)

<img width="512" alt="after-mobile" src="https://user-images.githubusercontent.com/3039310/39382791-b6f9ef56-4a34-11e8-9707-7573c879816d.png">

---

### Before (small screen)

<img width="512" alt="before" src="https://user-images.githubusercontent.com/3039310/39382793-bdf603a8-4a34-11e8-8b69-3c6633332f7c.png">

### After (small screen)

<img width="512" alt="after" src="https://user-images.githubusercontent.com/3039310/39382796-c3a5dd3c-4a34-11e8-964f-f67f66100877.png">
